### PR TITLE
Add support for updating IPv6

### DIFF
--- a/root/app/duck.sh
+++ b/root/app/duck.sh
@@ -1,9 +1,30 @@
 #!/usr/bin/with-contenv bash
 
 . /app/duck.conf
+
 RESPONSE=`curl -s "https://www.duckdns.org/update?domains=$SUBDOMAINS&token=$TOKEN&ip="`
 if [ "$RESPONSE" = "OK" ]; then
-echo "Your IP was updated at "$(date)
+  echo "Your IPv4 was updated at "$(date)
 else
-echo "Something went wrong, please check your settings  "$(date)
+  echo "Something went wrong when updating your IPv4, please check your settings  "$(date)
+  exit 1
+fi
+
+if [ ! "$UPDATE_IPV6" = "true" ]; then
+  echo "skipping IPv6 update..."
+  exit
+fi
+
+IPV6=`curl -s "https://v6.ident.me/"`
+if [ "$IPV6" = "" ]; then
+  echo "Problem fetching IPv6, skipping update..."
+  exit 1
+fi
+
+RESPONSE=`curl -s "https://www.duckdns.org/update?domains=$SUBDOMAINS&token=$TOKEN&ipv6=$IPV6"`
+if [ "$RESPONSE" = "OK" ]; then
+  echo "Your IPv6 was updated at "$(date)
+else
+  echo "Something went wrong when updating your IPv6, please check your settings  "$(date)
+  exit 1
 fi


### PR DESCRIPTION
Hello,
In this PR I'm trying to add IPv6 support to the image.

The biggest challenge I had was:
- how to obtain the ipv6, since we cannot just pass `ipv6=` and expect duckdns to fetch it automatically
- avoid a second request to duckdns, it seems that `ip=&ipv6=[actual_ipv6]` ends up only setting the IPv6 leaving the IPv4 untouched.

I'm unsure whether this is the right approach, but I couldn't find a way of making fewer HTTP requests.

I'm very open to suggestions. I'm not really good at bash.

@sparklyballs @aptalca 