### PR TITLE
Add PRIVATE_SUBDOMAINS option to update with local IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ services:
   duckdns:
     image: lscr.io/linuxserver/duckdns:latest
     container_name: duckdns
+    network_mode: host
     environment:
       - PUID=1000 #optional
       - PGID=1000 #optional
@@ -84,6 +85,7 @@ services:
       - SUBDOMAINS=subdomain1,subdomain2
       - TOKEN=token
       - LOG_FILE=false #optional
+      - PRIVATE_SUBDOMAINS=private_subdomain1,private_subdomain2 #optional
     volumes:
       - /path/to/appdata/config:/config #optional
     restart: unless-stopped
@@ -94,12 +96,14 @@ services:
 ```bash
 docker run -d \
   --name=duckdns \
+  --net=host \
   -e PUID=1000 `#optional` \
   -e PGID=1000 `#optional` \
   -e TZ=Europe/London \
   -e SUBDOMAINS=subdomain1,subdomain2 \
   -e TOKEN=token \
   -e LOG_FILE=false `#optional` \
+  -e PRIVATE_SUBDOMAINS=private_subdomain1,private_subdomain2 `#optional` \
   -v /path/to/appdata/config:/config `#optional` \
   --restart unless-stopped \
   lscr.io/linuxserver/duckdns:latest
@@ -111,12 +115,14 @@ Container images are configured using parameters passed at runtime (such as thos
 
 | Parameter | Function |
 | :----: | --- |
+| `--net=host` | Use Host Networking to be able to get the local private IP |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
 | `-e SUBDOMAINS=subdomain1,subdomain2` | multiple subdomains allowed, comma separated, no spaces |
 | `-e TOKEN=token` | DuckDNS token |
 | `-e LOG_FILE=false` | Set to `true` to log to file (also need to map /config). |
+| `-e PRIVATE_SUBDOMAINS=private_subdomain1,private_subdomain2` | multiple subdomains allowed, comma separated, no spaces. Needs host networking to be able to resolve the host private IP |
 | `-v /config` | Used in conjunction with logging to file. |
 
 ## Environment variables from files (Docker secrets)
@@ -230,6 +236,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **04.05.22:** - Add option to update domains with private local IP
 * **23.02.22:** - Append to log file instead of overwriting every time.
 * **03.05.21:** - Re-adjust cron timings to prevent peak times, update code formatting.
 * **23.01.21:** - Rebasing to alpine 3.13.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,6 +29,9 @@ param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "subdomain1,subdomain2", desc: "multiple subdomains allowed, comma separated, no spaces"}
   - { env_var: "TOKEN", env_value: "token", desc: "DuckDNS token"}
 param_usage_include_vols: false
+param_usage_include_net: true
+param_net: "host"
+param_net_desc: "Use Host Networking to be able to get the local private IP"
 param_volumes: ""
 param_usage_include_ports: false
 param_ports: ""
@@ -41,6 +44,7 @@ cap_add_param_vars: ""
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "LOG_FILE", env_value: "false", desc: "Set to `true` to log to file (also need to map /config)."}
+  - { env_var: "PRIVATE_SUBDOMAINS", env_value: "private_subdomain1,private_subdomain2", desc: "multiple subdomains allowed, comma separated, no spaces. Needs host networking to be able to resolve the host private IP"}
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Used in conjunction with logging to file." }
@@ -64,6 +68,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "04.05.22:", desc: "Add option to update domains with private local IP" }
   - { date: "23.02.22:", desc: "Append to log file instead of overwriting every time." }
   - { date: "03.05.21:", desc: "Re-adjust cron timings to prevent peak times, update code formatting." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }

--- a/root/app/duck.sh
+++ b/root/app/duck.sh
@@ -3,7 +3,21 @@
 . /app/duck.conf
 RESPONSE=$(curl -sSk "https://www.duckdns.org/update?domains=${SUBDOMAINS}&token=${TOKEN}&ip=")
 if [ "${RESPONSE}" = "OK" ]; then
-    echo "Your IP was updated at $(date)"
+    echo "$(date): Your IP was updated"
 else
-    echo -e "Something went wrong, please check your settings $(date)\nThe response returned was:\n${RESPONSE}"
+    echo -e "$(date): Something went wrong, please check your settings.\nThe response returned was:\n${RESPONSE}"
+fi
+
+if [ -n "${PRIVATE_SUBDOMAINS}" ]; then
+    PRIVATE_IP=$(ip -4 route get 8.8.8.8 2>/dev/null | awk {'print $7'} | tr -d '\n')
+    if [ -n "$PRIVATE_IP" ]; then
+        RESPONSE=$(curl -sS --max-time 60 "https://www.duckdns.org/update?domains=${PRIVATE_SUBDOMAINS}&token=${TOKEN}&ip=${PRIVATE_IP}")
+        if [ "${RESPONSE}" = "OK" ]; then
+            echo "$(date): Your private IP was updated to ${PRIVATE_IP}"
+        else
+            echo -e "$(date): Something went wrong updating your private IP to ${PRIVATE_IP}, please check your settings\nThe response returned was:\n${RESPONSE}"
+        fi
+    else
+        echo "$(date): No assigned private IP found"
+    fi
 fi

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -6,7 +6,7 @@ if [ -z "$SUBDOMAINS" ] || [ -z "$TOKEN" ]; then
   exit 1
 else
   echo "Retrieving subdomain and token from the environment variables"
-  echo -e "SUBDOMAINS=\"${SUBDOMAINS}\" TOKEN=\"${TOKEN}\"" > /app/duck.conf
+  echo -e "SUBDOMAINS=\"${SUBDOMAINS}\" TOKEN=\"${TOKEN}\" PRIVATE_SUBDOMAINS=\"${PRIVATE_SUBDOMAINS}\"" | tee /app/duck.conf
 fi
 
 # modify crontab if logging to file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-duckdns/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Normal updates to duckdns will set the domains to your public IP. This allows you to define domains that will be updated with your private IP.


Also change log format to start with the date for better readability.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Useful when you run a server on a private network where only dynamic IP allocation is available.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested all cases:
* invalid PRIVATE_SUBDOMAINS
* no ip assigned by dhcp
* normal operation. Log produced:
```
duckdns    | [cont-init.d] 10-adduser: exited 0.
duckdns    | [cont-init.d] 40-config: executing... 
duckdns    | Retrieving subdomain and token from the environment variables
duckdns    | SUBDOMAINS="foo" TOKEN="1234-1234-1234-1324" PRIVATE_SUBDOMAINS="foo-private"
duckdns    | log will be output to docker log
duckdns    | Wed May  4 12:14:51 UTC 2022: Your IP was updated
duckdns    | Wed May  4 12:14:54 UTC 2022: Your private IP was updated to 192.168.245.25
duckdns    | [cont-init.d] 40-config: exited 0.
duckdns    | [cont-init.d] 90-custom-folders: executing... 
duckdns    | [cont-init.d] 90-custom-folders: exited 0.
duckdns    | [cont-init.d] 99-custom-files: executing... 
duckdns    | [custom-init] no custom files found exiting...
duckdns    | [cont-init.d] 99-custom-files: exited 0.
duckdns    | [cont-init.d] done.
duckdns    | [services.d] starting services
duckdns    | [services.d] done.
```

And log when connectivity is lost:
```
duckdns    | curl: (6) Could not resolve host: www.duckdns.org
duckdns    | Thu May  5 07:39:27 UTC 2022: Something went wrong, please check your settings.
duckdns    | The response returned was:
duckdns    | 
duckdns    | Thu May  5 07:39:27 UTC 2022: No assigned private IP found
``` 

## Source / References:

Used in the IOTstack project: https://ukkopahis.github.io/IOTstack/Containers/Duckdns/#domain-name-for-the-private-ip
