### PR TITLE
Rework shell scripts and cron logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -440,7 +440,8 @@ pipeline {
       }
       steps {
         echo "Running on node: ${NODE_NAME}"
-        sh "docker build \
+        sh "sed -r -i 's|(^FROM .*)|\\1\\n\\nENV LSIO_FIRST_PARTY=true|g' Dockerfile"
+        sh "docker buildx build \
           --label \"org.opencontainers.image.created=${GITHUB_DATE}\" \
           --label \"org.opencontainers.image.authors=linuxserver.io\" \
           --label \"org.opencontainers.image.url=https://github.com/linuxserver/docker-duckdns/packages\" \
@@ -453,7 +454,7 @@ pipeline {
           --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
           --label \"org.opencontainers.image.title=Duckdns\" \
           --label \"org.opencontainers.image.description=[Duckdns](https://duckdns.org/) is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.\" \
-          --no-cache --pull -t ${IMAGE}:${META_TAG} \
+          --no-cache --pull -t ${IMAGE}:${META_TAG} --platform=linux/amd64 \
           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
       }
     }
@@ -470,7 +471,8 @@ pipeline {
         stage('Build X86') {
           steps {
             echo "Running on node: ${NODE_NAME}"
-            sh "docker build \
+            sh "sed -r -i 's|(^FROM .*)|\\1\\n\\nENV LSIO_FIRST_PARTY=true|g' Dockerfile"
+            sh "docker buildx build \
               --label \"org.opencontainers.image.created=${GITHUB_DATE}\" \
               --label \"org.opencontainers.image.authors=linuxserver.io\" \
               --label \"org.opencontainers.image.url=https://github.com/linuxserver/docker-duckdns/packages\" \
@@ -483,7 +485,7 @@ pipeline {
               --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
               --label \"org.opencontainers.image.title=Duckdns\" \
               --label \"org.opencontainers.image.description=[Duckdns](https://duckdns.org/) is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.\" \
-              --no-cache --pull -t ${IMAGE}:amd64-${META_TAG} \
+              --no-cache --pull -t ${IMAGE}:amd64-${META_TAG} --platform=linux/amd64 \
               --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
           }
         }
@@ -497,7 +499,8 @@ pipeline {
             sh '''#! /bin/bash
                   echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
                '''
-            sh "docker build \
+            sh "sed -r -i 's|(^FROM .*)|\\1\\n\\nENV LSIO_FIRST_PARTY=true|g' Dockerfile.armhf"
+            sh "docker buildx build \
               --label \"org.opencontainers.image.created=${GITHUB_DATE}\" \
               --label \"org.opencontainers.image.authors=linuxserver.io\" \
               --label \"org.opencontainers.image.url=https://github.com/linuxserver/docker-duckdns/packages\" \
@@ -510,7 +513,7 @@ pipeline {
               --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
               --label \"org.opencontainers.image.title=Duckdns\" \
               --label \"org.opencontainers.image.description=[Duckdns](https://duckdns.org/) is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.\" \
-              --no-cache --pull -f Dockerfile.armhf -t ${IMAGE}:arm32v7-${META_TAG} \
+              --no-cache --pull -f Dockerfile.armhf -t ${IMAGE}:arm32v7-${META_TAG} --platform=linux/arm/v7 \
               --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
             sh "docker tag ${IMAGE}:arm32v7-${META_TAG} ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}"
             retry(5) {
@@ -531,7 +534,8 @@ pipeline {
             sh '''#! /bin/bash
                   echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
                '''
-            sh "docker build \
+            sh "sed -r -i 's|(^FROM .*)|\\1\\n\\nENV LSIO_FIRST_PARTY=true|g' Dockerfile.aarch64"
+            sh "docker buildx build \
               --label \"org.opencontainers.image.created=${GITHUB_DATE}\" \
               --label \"org.opencontainers.image.authors=linuxserver.io\" \
               --label \"org.opencontainers.image.url=https://github.com/linuxserver/docker-duckdns/packages\" \
@@ -544,7 +548,7 @@ pipeline {
               --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
               --label \"org.opencontainers.image.title=Duckdns\" \
               --label \"org.opencontainers.image.description=[Duckdns](https://duckdns.org/) is a free service which will point a DNS (sub domains of duckdns.org) to an IP of your choice. The service is completely free, and doesn't require reactivation or forum posts to maintain its existence.\" \
-              --no-cache --pull -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} \
+              --no-cache --pull -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} --platform=linux/arm64 \
               --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
             sh "docker tag ${IMAGE}:arm64v8-${META_TAG} ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
             retry(5) {
@@ -573,26 +577,12 @@ pipeline {
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}
               fi
-              if [ "${DIST_IMAGE}" == "alpine" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apk info -v > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "ubuntu" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apt list -qq --installed | sed "s#/.*now ##g" | cut -d" " -f1 > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "fedora" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  rpm -qa > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "arch" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  pacman -Q > /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              fi
+              touch ${TEMPDIR}/package_versions.txt
+              docker run --rm \
+                -v /var/run/docker.sock:/var/run/docker.sock:ro \
+                -v ${TEMPDIR}:/tmp \
+                ghcr.io/anchore/syft:latest \
+                ${LOCAL_CONTAINER} -o table=/tmp/package_versions.txt
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )
               echo "Package tag sha from current packages in buit container is ${NEW_PACKAGE_TAG} comparing to old ${PACKAGE_TAG} from github"
               if [ "${NEW_PACKAGE_TAG}" != "${PACKAGE_TAG}" ]; then

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.03.23:** - Rework shell scripts and cron logic.
 * **13.02.23:** - Rebase to alpine 3.17.
 * **23.09.22:** - Rebase to alpine 3.16 and s6v3.
 * **19.09.22:** - Rebase to alpine 3.15.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -64,6 +64,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.03.23:", desc: "Rework shell scripts and cron logic." }
   - { date: "13.02.23:", desc: "Rebase to alpine 3.17." }
   - { date: "23.09.22:", desc: "Rebase to alpine 3.16 and s6v3." }
   - { date: "19.09.22:", desc: "Rebase to alpine 3.15." }

--- a/root/app/duck.sh
+++ b/root/app/duck.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-# shellcheck source=/dev/null
-. /app/duck.conf
-RESPONSE=$(curl -sS --max-time 60 "https://www.duckdns.org/update?domains=${SUBDOMAINS}&token=${TOKEN}&ip=")
-if [ "${RESPONSE}" = "OK" ]; then
-    echo "Your IP was updated at $(date)"
+if [ "${LOG_FILE}" = "true" ]; then
+    LOG_FILE="/config/duck.log"
+    touch "${LOG_FILE}"
+    /usr/sbin/logrotate /app/logrotate.conf
 else
-    echo -e "Something went wrong, please check your settings $(date)\nThe response returned was:\n${RESPONSE}"
+    LOG_FILE="/dev/null"
 fi
+
+{
+    RESPONSE=$(curl -sS --max-time 60 "https://www.duckdns.org/update?domains=${SUBDOMAINS}&token=${TOKEN}&ip=")
+    if [ "${RESPONSE}" = "OK" ]; then
+        echo "Your IP was updated at $(date)"
+    else
+        echo -e "Something went wrong, please check your settings $(date)\nThe response returned was:\n${RESPONSE}"
+    fi
+} | tee -a "${LOG_FILE}"

--- a/root/app/duck.sh
+++ b/root/app/duck.sh
@@ -2,11 +2,12 @@
 # shellcheck shell=bash
 
 if [ "${LOG_FILE}" = "true" ]; then
-    LOG_FILE="/config/duck.log"
-    touch "${LOG_FILE}"
-    /usr/sbin/logrotate /app/logrotate.conf
+    DUCK_LOG="/config/duck.log"
+    touch "${DUCK_LOG}"
+    touch /config/logrotate.status
+    /usr/sbin/logrotate -s /config/logrotate.status /app/logrotate.conf
 else
-    LOG_FILE="/dev/null"
+    DUCK_LOG="/dev/null"
 fi
 
 {
@@ -16,4 +17,4 @@ fi
     else
         echo -e "Something went wrong, please check your settings $(date)\nThe response returned was:\n${RESPONSE}"
     fi
-} | tee -a "${LOG_FILE}"
+} | tee -a "${DUCK_LOG}"

--- a/root/defaults/duckcron
+++ b/root/defaults/duckcron
@@ -1,2 +1,0 @@
-2,7,12,17,22,27,32,37,42,47,52,57 * * * * /app/duck.sh 2>&1 >> /config/duck.log
-0 0 * * * /usr/sbin/logrotate /app/logrotate.conf

--- a/root/etc/s6-overlay/s6-rc.d/init-duckdns/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-duckdns/run
@@ -1,20 +1,10 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 #Check to make sure the subdomain and token are set
 if [ -z "${SUBDOMAINS}" ] || [ -z "${TOKEN}" ]; then
     echo "Please pass both your subdomain(s) and token as environment variables in your docker run command. See the readme for more details."
     sleep infinity
-else
-    echo "Retrieving subdomain and token from the environment variables"
-    echo -e "SUBDOMAINS=\"${SUBDOMAINS}\" TOKEN=\"${TOKEN}\"" >/app/duck.conf
-fi
-
-# modify crontab if logging to file
-if [ "${LOG_FILE}" = "true" ]; then
-    crontab -u abc /defaults/duckcron
-    echo "log will be output to file"
-else
-    echo "log will be output to docker log"
 fi
 
 # permissions

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-exec \
-    /usr/sbin/crond -f -S -l 0 -c /etc/crontabs
+exec /usr/sbin/crond -f -S -l 5


### PR DESCRIPTION
- No need to carry vars from init to app using `/app/duck.conf` (it just used vars from env)
- If `LOG_FILE` env var is set to `true`, have `duck.sh` output to `/config/duck.log` and console using `tee`
- If `LOG_FILE` env var is not set to `true`, have `duck.sh` output to `/dev/null` and console using `tee`
- Wrap `duck.sh` logic in `{` braces `}` and pipe to `tee` to output to console and log file (or null)
- Have `duck.sh` run logrotate if `LOG_FILE` env var is set to `true`
- Remove `duckcron` (above logic replaces the need)
- Update `cron` service file to follow all other cron implementations
- Use `/config/logrotate.status` to prevent permission issues

Tested and working