### PR TITLE
Bump CI_DELAY to 120 seconds as ARM builds were failing.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     CI_WEB='false'
     CI_PORT=''
     CI_SSL=''
-    CI_DELAY='5'
+    CI_DELAY='120'
     CI_DOCKERENV='SUBDOMAINS=testing|TOKEN=testing'
     CI_AUTH=''
     CI_WEBPATH=''

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -21,7 +21,7 @@ repo_vars:
   - CI_WEB='false'
   - CI_PORT=''
   - CI_SSL=''
-  - CI_DELAY='5'
+  - CI_DELAY='120'
   - CI_DOCKERENV='SUBDOMAINS=testing|TOKEN=testing'
   - CI_AUTH=''
   - CI_WEBPATH=''

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "17.06.24:", desc: "Bump CI_DELAY to 120 seconds as ARM builds were failing." }
   - { date: "30.03.24:", desc: "Added IP address to logging output when IP changes." }
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19." }
   - { date: "14.10.23:", desc: "Rework shell script for case insensitivity and update readme to be more clear." }


### PR DESCRIPTION
ARM init test is failing because of the 5 second timeout. 

https://ci-tests.linuxserver.io/linuxserver/duckdns/d63af1c1-ls21/index.html